### PR TITLE
Replace php7.4 version for php8.2

### DIFF
--- a/tasks/host_bootstrap.yml
+++ b/tasks/host_bootstrap.yml
@@ -13,34 +13,30 @@
   become: true
   when: snipe_clean_env
 
-- name: Host Bootstrap | Install PHP 7.4 packages
+- name: Host Bootstrap | Install PHP 8.2 packages
   apt:
     name: "{{ packages }}"
     state: present
   vars:
     packages:
-    - php7.4-common
+    - php8.2-common
     - php-pear
-    - php7.4-bcmath
-    - php7.4-cli
-    - php7.4-common
-    - php7.4-curl
-    - php7.4-dev
-    - php7.4-gd
-    - php7.4-intl
-    - php7.4-json
-    - php7.4-ldap
-    - php7.4-mbstring
-    - php7.4-mysql
-    - php7.4-opcache
-    - php7.4-readline
-    - php7.4-xml
-    - php7.4-zip
+    - php8.2-bcmath
+    - php8.2-cli
+    - php8.2-common
+    - php8.2-curl
+    - php8.2-gd
+    - php8.2-ldap
+    - php8.2-mbstring
+    - php8.2-mysql
+    - php8.2-readline
+    - php8.2-xml
+    - php8.2-zip
   become: true
 
 - name: Host Bootstrap | Install Nginx and PHP-FPM
   apt:
-    name: [nginx, php7.4-fpm]
+    name: [nginx, php8.2-fpm]
     state: present
   when: snipe_http_server == "nginx"
   become: true

--- a/templates/snipeit.conf.j2
+++ b/templates/snipeit.conf.j2
@@ -12,7 +12,7 @@ server {
 		try_files $uri $uri/ /index.php$is_args$args;
 	}
 	location ~* \.php$ {
-            fastcgi_pass unix:/run/php/php7.4-fpm.sock;
+            fastcgi_pass unix:/run/php/php8.2-fpm.sock;
             include         fastcgi_params;
             fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
             fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;


### PR DESCRIPTION
With the Debian 12 upgrade, PHP v8.2 is now the supported version