### PR TITLE
refactor: Replace root password task with dedicated DB user

### DIFF
--- a/tasks/host_bootstrap.yml
+++ b/tasks/host_bootstrap.yml
@@ -48,16 +48,13 @@
   become: true
   register: mysqlinstall
 
-- name: Set MySQL root Password
-  become: True
-  mysql_user: 
-    name: root
+- name: Create database user
+  mysql_user:
+    name: "{{ snipe_db_user }}"
     password: "{{ snipe_db_pass }}"
-    check_implicit_admin: yes
-    login_user: "root"
-    login_password: ""
+    check_implicit_admin: true
+    priv: '*.*:ALL'
     state: present
-  when: mysqlinstall.changed
 
 - name: Host Bootstrap | Mysql | Create database
   mysql_db:


### PR DESCRIPTION
When you try to connect as root (even as OS root), MySQL expects the password you just set. If you try to connect without a password (e.g., sudo mysql or mysql -u root), it fails because the unix_socket method is no longer active for that user, and the new mysql_native_password method requires a password. 

This was the reason the playbook failed on its second run